### PR TITLE
Redesign build step card — piece images, animation, no LDraw viewer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [{ protocol: "https", hostname: "cdn.rebrickable.com" }],
+  },
 };
 
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,3 +17,9 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }
+
+@keyframes stepIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.step-animate { animation: stepIn 0.22s ease both; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import BrickShelf from "@/components/brick-shelf";
 import MysteryPieceScanner from "@/components/camera-upload";
 import ThemePicker from "@/components/theme-picker";
 import BuildSelection from "@/components/build-selection";
-import BuildInstructions from "@/components/build-instructions";
+import { BuildInstructions } from "@/components/build-instructions";
 import LoadingState from "@/components/loading-state";
 import Confetti from "@/components/confetti";
 import WelcomeScreen from "@/components/welcome-screen";

--- a/src/components/build-instructions.tsx
+++ b/src/components/build-instructions.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import dynamic from "next/dynamic";
 import type { BuildSuggestion, BuildStep } from "@/lib/types";
 import { useAudio } from "@/hooks/use-audio";
-import { generateLDraw } from "@/lib/ldraw-generator";
-
-// Three.js must only run on the client — skip SSR entirely.
-const LDrawViewer = dynamic(() => import("./ldraw-viewer"), { ssr: false });
-
-// Asset: /public/snap.mp3 required — add a short CC0 click/snap sound
 
 const DIFFICULTY_LABELS: Record<number, string> = {
   1: "Easy",
@@ -44,20 +37,12 @@ export default function BuildInstructions({
   const step = suggestion.steps[currentStep];
   const isLastStep = currentStep === totalSteps - 1;
 
-  // 1-based step index for the cumulative LDraw model and label.
-  const ldrawStep = currentStep + 1;
-  const ldrawContent = generateLDraw(suggestion.steps, ldrawStep);
-
-  // Speak the instruction when the step changes
   useEffect(() => {
-    if (step) {
-      speak(step.instruction);
-    }
+    if (step) speak(step.instruction);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentStep]);
 
   const goNext = () => {
-    // Asset: /public/snap.mp3 required — add a short CC0 click/snap sound
     playSnap();
     if (isLastStep) {
       setDone(true);
@@ -68,75 +53,72 @@ export default function BuildInstructions({
     }
   };
 
-  const goPrev = () => {
-    setCurrentStep((s) => Math.max(0, s - 1));
-  };
+  const goPrev = () => setCurrentStep((s) => Math.max(0, s - 1));
 
-  if (done) {
-    return <FinishedScreen onReset={onReset} onBack={onBack} />;
-  }
+  if (done) return <FinishedScreen onReset={onReset} onBack={onBack} />;
+
+  const progress = ((currentStep + 1) / totalSteps) * 100;
 
   return (
     <div className="w-full space-y-4">
+      <style>{`
+        @keyframes stepIn {
+          from { opacity: 0; transform: translateY(10px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .step-animate { animation: stepIn 0.22s ease both; }
+      `}</style>
+
       {/* Header */}
       <div className="text-center">
         <h2 className="text-xl font-bold text-gray-900">{suggestion.title}</h2>
-        <p className="text-gray-500 text-sm mt-1">{suggestion.description}</p>
+        <p className="text-gray-500 text-sm mt-0.5">{suggestion.description}</p>
         <div className="flex items-center justify-center gap-2 mt-2">
-          <span
-            className={`px-2 py-0.5 rounded-full text-xs font-semibold ${
-              DIFFICULTY_COLORS[suggestion.difficulty] ?? "bg-gray-100 text-gray-700"
-            }`}
-          >
+          <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${DIFFICULTY_COLORS[suggestion.difficulty] ?? "bg-gray-100 text-gray-700"}`}>
             {DIFFICULTY_LABELS[suggestion.difficulty] ?? `Level ${suggestion.difficulty}`}
           </span>
           <span className="text-xs text-gray-400">~{suggestion.estimatedTime}</span>
         </div>
       </div>
 
-      {/* Progress bar */}
-      <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
-        <div
-          className="h-2 bg-yellow-400 rounded-full transition-all duration-300"
-          style={{ width: `${((currentStep + 1) / totalSteps) * 100}%` }}
-        />
-      </div>
-      <p className="text-center text-xs text-gray-400">
-        Step {currentStep + 1} of {totalSteps}
-      </p>
-
-      {/* 3D model viewer — updates with each step */}
-      <div className="rounded-2xl overflow-hidden mb-4">
-        <LDrawViewer
-          ldrawContent={ldrawContent}
-          stepLabel={`Step ${ldrawStep} of ${totalSteps}`}
-        />
+      {/* Progress */}
+      <div>
+        <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
+          <div
+            className="h-2 bg-yellow-400 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <p className="text-center text-xs text-gray-400 mt-1">
+          Step {currentStep + 1} of {totalSteps}
+        </p>
       </div>
 
-      {/* Step card */}
-      <div className="bg-white rounded-2xl border-2 border-yellow-400 overflow-hidden">
-        <div className="bg-yellow-400 px-4 py-3 flex items-center gap-3">
-          <div className="w-8 h-8 rounded-full bg-black text-yellow-400 font-black flex items-center justify-center text-sm">
+      {/* Step card — key forces full re-mount + animation on step change */}
+      <div key={currentStep} className="step-animate space-y-4">
+        {/* Instruction */}
+        <div className="bg-yellow-400 rounded-2xl px-4 py-4 flex gap-3 items-start">
+          <div className="w-9 h-9 rounded-full bg-black text-yellow-400 font-black text-base flex items-center justify-center flex-shrink-0">
             {step.stepNumber}
           </div>
-          <span className="font-bold text-black text-sm">
-            Step {step.stepNumber}
-          </span>
-        </div>
-        <div className="p-4">
-          <p className="text-gray-900 font-medium leading-relaxed text-base">
+          <p className="text-black font-semibold text-base leading-snug pt-1">
             {step.instruction}
           </p>
+        </div>
 
-          {/* Piece chips */}
-          {step.piecesUsed && step.piecesUsed.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-2">
+        {/* Parts for this step */}
+        {step.piecesUsed && step.piecesUsed.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2 px-1">
+              Pieces for this step
+            </p>
+            <div className="grid grid-cols-2 gap-3">
               {step.piecesUsed.map((piece, i) => (
-                <PieceChip key={i} piece={piece} />
+                <PieceCard key={i} piece={piece} />
               ))}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
       {/* Navigation */}
@@ -152,7 +134,7 @@ export default function BuildInstructions({
           disabled={currentStep === 0}
           className="px-4 py-2.5 rounded-full bg-gray-100 text-gray-700 font-semibold disabled:opacity-30 hover:bg-gray-200 transition-colors"
         >
-          Previous
+          Prev
         </button>
         <button
           onClick={goNext}
@@ -160,10 +142,10 @@ export default function BuildInstructions({
           className={`py-2.5 rounded-full font-bold text-base transition-all active:scale-95 ${
             isLastStep
               ? "bg-green-500 text-white hover:bg-green-600"
-              : "bg-yellow-400 text-black hover:bg-yellow-500"
+              : "bg-gray-900 text-white hover:bg-gray-700"
           }`}
         >
-          {isLastStep ? "I Did It! ✓" : "Next →"}
+          {isLastStep ? "Done! ✓" : "Next step →"}
         </button>
       </div>
 
@@ -184,7 +166,6 @@ export default function BuildInstructions({
         </div>
       )}
 
-      {/* Restart */}
       <div className="text-center">
         <button
           onClick={onReset}
@@ -197,60 +178,59 @@ export default function BuildInstructions({
   );
 }
 
-/** Individual piece chip shown in a step */
-function PieceChip({ piece }: { piece: BuildStep["piecesUsed"][number] }) {
+function PieceCard({ piece }: { piece: BuildStep["piecesUsed"][number] }) {
   const [imgErrored, setImgErrored] = useState(false);
 
   return (
-    <div className="flex items-center gap-1.5 bg-gray-50 border border-gray-200 rounded-full px-2.5 py-1">
-      {/* Color dot */}
-      <span
-        style={{
-          display: "inline-block",
-          width: "10px",
-          height: "10px",
-          borderRadius: "50%",
-          backgroundColor: piece.colorHex,
-          border: "1px solid rgba(0,0,0,0.15)",
-          flexShrink: 0,
-        }}
-      />
+    <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden flex flex-col">
+      {/* Color strip */}
+      <div style={{ backgroundColor: piece.colorHex, height: "5px" }} />
 
-      {/* Part image */}
-      {!imgErrored ? (
-        <img
-          src={piece.imgUrl}
-          alt={piece.name}
-          style={{ width: "20px", height: "20px", objectFit: "contain" }}
-          onError={() => setImgErrored(true)}
-        />
-      ) : (
-        <div
-          style={{
-            width: "20px",
-            height: "20px",
-            borderRadius: "3px",
-            backgroundColor: "#D1D5DB",
-            flexShrink: 0,
-          }}
-        />
-      )}
+      <div className="p-3 flex gap-3 items-center flex-1">
+        {/* Part image with quantity badge */}
+        <div className="relative flex-shrink-0">
+          {!imgErrored ? (
+            <img
+              src={piece.imgUrl}
+              alt={piece.name}
+              className="w-16 h-16 object-contain"
+              onError={() => setImgErrored(true)}
+            />
+          ) : (
+            <div
+              className="w-16 h-16 rounded-xl flex items-center justify-center text-2xl"
+              style={{ backgroundColor: piece.colorHex + "33" }}
+            >
+              🧱
+            </div>
+          )}
+          <div
+            className="absolute -top-1 -right-1 w-6 h-6 rounded-full flex items-center justify-center text-xs font-black text-white shadow"
+            style={{ backgroundColor: "#111" }}
+          >
+            {piece.quantity}
+          </div>
+        </div>
 
-      <span className="text-xs font-medium text-gray-700">
-        {piece.quantity}× {piece.name}
-      </span>
+        {/* Info */}
+        <div className="min-w-0">
+          <p className="text-xs text-gray-700 font-medium leading-tight line-clamp-2">
+            {piece.name}
+          </p>
+          <div className="flex items-center gap-1 mt-1">
+            <span
+              className="inline-block w-2.5 h-2.5 rounded-full border border-black/10 flex-shrink-0"
+              style={{ backgroundColor: piece.colorHex }}
+            />
+            <span className="text-xs text-gray-400 truncate">{piece.color}</span>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
 
-/** Shown when all steps are complete */
-function FinishedScreen({
-  onReset,
-  onBack,
-}: {
-  onReset: () => void;
-  onBack: () => void;
-}) {
+function FinishedScreen({ onReset, onBack }: { onReset: () => void; onBack: () => void }) {
   return (
     <div className="w-full flex flex-col items-center py-8 space-y-6 text-center">
       <div className="text-7xl">🎉</div>

--- a/src/components/build-instructions.tsx
+++ b/src/components/build-instructions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import type { BuildSuggestion, BuildStep } from "@/lib/types";
 import { useAudio } from "@/hooks/use-audio";
 
@@ -39,6 +40,7 @@ export default function BuildInstructions({
 
   useEffect(() => {
     if (step) speak(step.instruction);
+    // speak is stable (useCallback with no deps in useAudio)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentStep]);
 
@@ -113,8 +115,8 @@ export default function BuildInstructions({
               Pieces for this step
             </p>
             <div className="grid grid-cols-2 gap-3">
-              {step.piecesUsed.map((piece, i) => (
-                <PieceCard key={i} piece={piece} />
+              {step.piecesUsed.map((piece) => (
+                <PieceCard key={`${piece.partNum}-${piece.color}`} piece={piece} />
               ))}
             </div>
           </div>
@@ -156,8 +158,8 @@ export default function BuildInstructions({
             <span>💡</span> Tips
           </h3>
           <ul className="space-y-1">
-            {suggestion.tips.map((tip, i) => (
-              <li key={i} className="text-sm text-blue-800 flex gap-2">
+            {suggestion.tips.map((tip) => (
+              <li key={tip} className="text-sm text-blue-800 flex gap-2">
                 <span className="text-blue-400 mt-0.5">•</span>
                 {tip}
               </li>
@@ -190,10 +192,12 @@ function PieceCard({ piece }: { piece: BuildStep["piecesUsed"][number] }) {
         {/* Part image with quantity badge */}
         <div className="relative flex-shrink-0">
           {!imgErrored ? (
-            <img
+            <Image
               src={piece.imgUrl}
               alt={piece.name}
-              className="w-16 h-16 object-contain"
+              width={64}
+              height={64}
+              className="object-contain"
               onError={() => setImgErrored(true)}
             />
           ) : (

--- a/src/components/build-instructions.tsx
+++ b/src/components/build-instructions.tsx
@@ -63,14 +63,6 @@ export default function BuildInstructions({
 
   return (
     <div className="w-full space-y-4">
-      <style>{`
-        @keyframes stepIn {
-          from { opacity: 0; transform: translateY(10px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-        .step-animate { animation: stepIn 0.22s ease both; }
-      `}</style>
-
       {/* Header */}
       <div className="text-center">
         <h2 className="text-xl font-bold text-gray-900">{suggestion.title}</h2>
@@ -158,8 +150,8 @@ export default function BuildInstructions({
             <span>💡</span> Tips
           </h3>
           <ul className="space-y-1">
-            {suggestion.tips.map((tip) => (
-              <li key={tip} className="text-sm text-blue-800 flex gap-2">
+            {suggestion.tips.map((tip, i) => (
+              <li key={`tip-${i}`} className="text-sm text-blue-800 flex gap-2">
                 <span className="text-blue-400 mt-0.5">•</span>
                 {tip}
               </li>
@@ -226,7 +218,7 @@ function PieceCard({ piece }: { piece: BuildStep["piecesUsed"][number] }) {
               className="inline-block w-2.5 h-2.5 rounded-full border border-black/10 flex-shrink-0"
               style={{ backgroundColor: piece.colorHex }}
             />
-            <span className="text-xs text-gray-400 truncate">{piece.color}</span>
+            <span className="text-xs text-gray-600 truncate">{piece.color}</span>
           </div>
         </div>
       </div>

--- a/src/components/build-instructions.tsx
+++ b/src/components/build-instructions.tsx
@@ -24,7 +24,7 @@ interface BuildInstructionsProps {
   onComplete: () => void;
 }
 
-export default function BuildInstructions({
+export function BuildInstructions({
   suggestion,
   onReset,
   onBack,
@@ -71,7 +71,7 @@ export default function BuildInstructions({
           <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${DIFFICULTY_COLORS[suggestion.difficulty] ?? "bg-gray-100 text-gray-700"}`}>
             {DIFFICULTY_LABELS[suggestion.difficulty] ?? `Level ${suggestion.difficulty}`}
           </span>
-          <span className="text-xs text-gray-400">~{suggestion.estimatedTime}</span>
+          <span className="text-xs text-gray-600">~{suggestion.estimatedTime}</span>
         </div>
       </div>
 
@@ -83,7 +83,7 @@ export default function BuildInstructions({
             style={{ width: `${progress}%` }}
           />
         </div>
-        <p className="text-center text-xs text-gray-400 mt-1">
+        <p className="text-center text-xs text-gray-600 mt-1">
           Step {currentStep + 1} of {totalSteps}
         </p>
       </div>
@@ -103,7 +103,7 @@ export default function BuildInstructions({
         {/* Parts for this step */}
         {step.piecesUsed && step.piecesUsed.length > 0 && (
           <div>
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2 px-1">
+            <p className="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-2 px-1">
               Pieces for this step
             </p>
             <div className="grid grid-cols-2 gap-3">
@@ -132,8 +132,7 @@ export default function BuildInstructions({
         </button>
         <button
           onClick={goNext}
-          style={{ flex: 1 }}
-          className={`py-2.5 rounded-full font-bold text-base transition-all active:scale-95 ${
+          className={`flex-1 py-2.5 rounded-full font-bold text-base transition-all active:scale-95 ${
             isLastStep
               ? "bg-green-500 text-white hover:bg-green-600"
               : "bg-gray-900 text-white hover:bg-gray-700"
@@ -163,7 +162,7 @@ export default function BuildInstructions({
       <div className="text-center">
         <button
           onClick={onReset}
-          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+          className="text-sm text-gray-600 hover:text-gray-800 transition-colors"
         >
           Start over
         </button>
@@ -201,8 +200,7 @@ function PieceCard({ piece }: { piece: BuildStep["piecesUsed"][number] }) {
             </div>
           )}
           <div
-            className="absolute -top-1 -right-1 w-6 h-6 rounded-full flex items-center justify-center text-xs font-black text-white shadow"
-            style={{ backgroundColor: "#111" }}
+            className="absolute -top-1 -right-1 w-6 h-6 rounded-full flex items-center justify-center text-xs font-black text-white shadow bg-gray-900"
           >
             {piece.quantity}
           </div>


### PR DESCRIPTION
## Summary
- Removes the Three.js/LDraw 3D viewer from the step-by-step instructions (slow GitHub CDN fetch, unreliable geometry from AI-generated placements)
- Replaces with a 2-column grid of piece cards: color strip, 64px Rebrickable part image, quantity badge, part name, color swatch
- Step transitions animate in via CSS `@keyframes stepIn` triggered by `key={currentStep}`
- Navigation, progress bar, tips, and finished screen unchanged

## Test plan
- [ ] Step through a build — each step card animates in and shows the correct pieces
- [ ] Piece images load from Rebrickable; fallback brick emoji shown on error
- [ ] Prev/Next/Done navigation works correctly
- [ ] Progress bar advances with each step